### PR TITLE
Huge block of changes to New-SlackRichNotification

### DIFF
--- a/Send-SlackMessage.ps1
+++ b/Send-SlackMessage.ps1
@@ -129,15 +129,27 @@ function New-SlackRichNotification
         [String]
         $Fallback,
 
-        [Parameter(Mandatory=$true,
+        <#[Parameter(Mandatory=$true,
                    Position=1)]
         [String]
         $Title,
-
+        
         [Parameter(Mandatory=$true,
                    Position=2)]
         [String]
         $Value,
+        #>
+        [Parameter(
+            Mandatory=$true,
+            Position=2
+        )]
+        [String]
+        $Text,
+        
+        [Parameter(Mandatory=$true,
+                   Position=2)]
+        [Array]
+        $Fields,
 
         [Parameter(Mandatory=$true,
                    Position=3)]
@@ -167,18 +179,14 @@ function New-SlackRichNotification
     Process
     {
         $SlackNotification = @{
+            text = $Text
             username = $UserName
             icon_url = $IconUrl
             attachments = @(
                 @{
                     fallback = $Fallback
                     color = $Severity
-                    fields = @(
-                        @{
-                            title = $Title
-                            value = $Value
-                        }
-                    )
+                    fields = $Fields
                 }    
             )
         }

--- a/Send-SlackMessage.ps1
+++ b/Send-SlackMessage.ps1
@@ -2,7 +2,7 @@
 .Synopsis
    Returns a hashtable containing the configuration for sending slack messages to web hook integrations.
 .DESCRIPTION
-   Sends a JSON payload to the designated webhook URL
+   Takes a Hashtable and converts it to JSON before it sends it to the designated webhook URL.
 .EXAMPLE
    Send-SlackNotification -Url "https://yourname.slack.com/path/to/hookintegrations" -Notification $Notification
 
@@ -57,13 +57,16 @@ function Send-SlackNotification
 .Synopsis
    Creates a rich notification (Attachment) to be posted in a slack channel.
 .DESCRIPTION
-   Outputs a Hashtable that can be converted to JSON and sent to a Webhook in Slack. 
+   Used to create Atachment message payloads for Slack. Attachemnts are a way of crafting richly-formatted messages in Slack. They can be as simple as a single plain text message, to as complex as a multi-line message with pictures, links and tables. 
 
 .PARAMETER Fallback
-A plain-text summary of the attachment(value parameter). This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
+A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
 
 .PARAMETER Severity
-This value is used to color the border along the left side of the message attachment.
+This value is used to color the border along the left side of the message attachment. At this stage only good, warning and danger are accepted in this function; even though the Slack API allows for Hex Colour Code.
+
+.PARAMETER Pretext
+This is optional text that appears above the message attachment block.
 
 .PARAMETER AuthorName
 Small text used to display the author's name.
@@ -177,12 +180,17 @@ function New-SlackRichNotification
                      "warning", 
                      "danger"
                      )]
+        [Alias("Color","Colour")]
         [String]
         $Severity,
 
         [Parameter(Mandatory=$false)]
         [String]
         $AuthorName,
+
+        [Parameter(Mandatory=$false)]
+        [String]
+        $Pretext,
 
         [Parameter(Mandatory=$false)]
         [String]

--- a/Send-SlackMessage.ps1
+++ b/Send-SlackMessage.ps1
@@ -63,22 +63,26 @@ function Send-SlackNotification
 A plain-text summary of the attachment(value parameter). This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
 
 .PARAMETER Title
-The title is displayed as larger, bold text near the top of a message attachment
+The title is displayed as larger, bold text near the top of the message attachment.
 
-.PARAMETER Value
-The message that you want to send. It may contain standard message markup and must be escaped as normal. May be multi-line.
+.PARAMETER TitleLink
+If the title link is specified then it turns the Title into a hyperlink that the user can click. 
 
 .PARAMETER Severity
 This value is used to color the border along the left side of the message attachment
 
 .PARAMETER Channel
-Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name. Not required if a webhook is used.
+Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name.
 
 .PARAMETER Username
 Can be used to change the name of the bot. If not specified, the custom Webhook name is used.
 
 .PARAMETER IconUrl
 URL to an image to use as the icon for this message
+
+
+.PARAMETER Text
+This is the main text in a message attachment, and can contain standard message markup. Not to be confused with Pretext which would appear above this.
 
 .NOTES
 This function does not utilise the full capability of Slack attachments and some modification may be required if you wish to extend it. 
@@ -123,54 +127,80 @@ function New-SlackRichNotification
     [OutputType([System.Collections.Hashtable])]
     Param
     (
-        
+        #<Attachment>
         [Parameter(Mandatory=$true,
                    Position=0)]
         [String]
         $Fallback,
-
-        <#[Parameter(Mandatory=$true,
-                   Position=1)]
-        [String]
-        $Title,
-        
-        [Parameter(Mandatory=$true,
-                   Position=2)]
-        [String]
-        $Value,
-        #>
-        [Parameter(
-            Mandatory=$true,
-            Position=2
-        )]
-        [String]
-        $Text,
-        
-        [Parameter(Mandatory=$true,
-                   Position=2)]
-        [Array]
-        $Fields,
-
-        [Parameter(Mandatory=$true,
-                   Position=3)]
-        [ValidateSet("good", "warning", "danger")]
-        [String]
-        $Severity,
         
         [Parameter(Mandatory=$false,
-                   Position=4)]
+                    Position=1)]
+        [ValidateSet("good",
+                     "warning", 
+                     "danger"
+                     )]
+        [String]
+        $Severity,
+
+        [Parameter(Mandatory=$false,
+                    ParameterSetName='Author Set'
+                    )]
+        [String]
+        $AuthorName,
+
+        [Parameter(Mandatory=$false,
+                    ParameterSetName='Author Set'
+                    )]
+        [String]
+        $AuthorLink,
+
+        [Parameter(Mandatory=$false,
+                    ParameterSetName='Author Set'
+                    )]
+        [String]
+        $AuthorIcon,
+
+        [Parameter(Mandatory=$false, #this could be mandatory. This needs testing. 
+                   ParameterSetName='Title Set'
+                   )]
+        [String]
+        $Title,
+
+        [Parameter(Mandatory=$false,
+                   ParameterSetName='Title Set'
+                   )]
+        [String]
+        $TitleLink,
+        
+        [Parameter(Mandatory=$false)]
+        [String]
+        $Text, #may be mandatory.
+
+        [Parameter(Mandatory=$false)]
+        [String]
+        $ImageURL,
+
+        [Parameter(Mandatory=$false)]
+        [String]
+        $ThumbURL,
+        
+        [Parameter(Mandatory=$false)]
+        [Array]
+        $Fields,
+        #</Attachment>
+        #<postMessage Arguments>
+        [Parameter(Mandatory=$false)]
         [String]
         $Channel,
 
-        [Parameter(Mandatory=$false,
-                   Position=5)]
+        [Parameter(Mandatory=$false)]
         [String]
         $UserName,
 
-        [Parameter(Mandatory=$false,
-                   Position=6)]
+        [Parameter(Mandatory=$false)]
         [String]
         $IconUrl
+        #</postMessage Arguments>
     )
 
     Begin
@@ -179,14 +209,22 @@ function New-SlackRichNotification
     Process
     {
         $SlackNotification = @{
-            text = $Text
             username = $UserName
             icon_url = $IconUrl
             attachments = @(
-                @{
+                @{                    
                     fallback = $Fallback
                     color = $Severity
-                    fields = $Fields
+                    pretext = $Pretext
+                    author_name = $AuthorName
+                    author_link = $AuthorLink
+                    author_icon = $AuthorIcon
+                    title = $Title
+                    title_link = $TitleLink
+                    text = $Text
+                    fields = $Fields #Fields are defined by the user as an Array of HashTables.
+                    image_url = $ImageURL
+                    thumb_url = $ThumbURL
                 }    
             )
         }
@@ -197,3 +235,10 @@ function New-SlackRichNotification
     {
     }
 }
+
+
+<#
+Change Notes:
+    - Removing positional paramater definition of optional parameters.
+
+#>

--- a/Send-SlackMessage.ps1
+++ b/Send-SlackMessage.ps1
@@ -62,14 +62,36 @@ function Send-SlackNotification
 .PARAMETER Fallback
 A plain-text summary of the attachment(value parameter). This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.
 
+.PARAMETER Severity
+This value is used to color the border along the left side of the message attachment.
+
+.PARAMETER AuthorName
+Small text used to display the author's name.
+
+.PARAMETER AuthorLink
+A valid URL that will hyperlink the AuthorName text mentioned above. Will only work if AuthorName is present.
+
+.PARAMETER AuthorIcon
+A valid URL that displays a small 16x16px image to the left of the AuthorName text. Will only work if AuthorName is present.
+
 .PARAMETER Title
 The title is displayed as larger, bold text near the top of the message attachment.
 
 .PARAMETER TitleLink
 If the title link is specified then it turns the Title into a hyperlink that the user can click. 
 
-.PARAMETER Severity
-This value is used to color the border along the left side of the message attachment
+.PARAMETER Text
+This is the main text in a message attachment, and can contain standard message markup. Not to be confused with Pretext which would appear above this.
+
+.PARAMETER ImageURL
+A valid URL to an image file that will be displayed inside a message attachment.
+
+.PARAMETER ThumbURL
+A valid URL to an image file that will be displayed as a thumbnail on the right side of a message attachment.
+
+.PARAMETER Fields
+Fields are defined as an array, and hashtables contained within it will be displayed in a table inside the message attachment.
+Each hashtable inside the array must contain a "title" parameter and a "value" parameter. Optionally it may also contain "Short" which is a boolean parameter.
 
 .PARAMETER Channel
 Channel to send message to. Can be a public channel, private group or IM channel. Can be an encoded ID, or a name.
@@ -80,17 +102,10 @@ Can be used to change the name of the bot. If not specified, the custom Webhook 
 .PARAMETER IconUrl
 URL to an image to use as the icon for this message
 
-
-.PARAMETER Text
-This is the main text in a message attachment, and can contain standard message markup. Not to be confused with Pretext which would appear above this.
-
-.NOTES
-This function does not utilise the full capability of Slack attachments and some modification may be required if you wish to extend it. 
-
 .EXAMPLE
    New-SlackRichNotification -Fallback "Your app sucks it should process attachments" -Title "Service Error" -Value "Service down for server contoso1" -Severity danger -channel "Operations" -UserName "Slack Powershell Bot"
    
-   This command would generate the following output:
+   This command would generate the following output in Powershell:
 -------------------------------------------------------------------------------
 
 Name                           Value                                                                                                                                                                                  
@@ -112,6 +127,29 @@ color                          danger
 fallback                       Your app sucks it should process attachments                                                                                                                                           
 fields                         {System.Collections.Hashtable}
 
+
+.EXAMPLE
+$MyFields = @(
+    @{
+        title = 'Assigned To'
+        value = 'John Doe'
+        short = 'true'
+    }
+    @{
+        title = 'Priority'
+        value = 'Super Critical!'
+        short = 'true'
+    }
+)
+
+$notification = New-SlackRichNotification -Fallback "A plaintext message" -Title "Description" -Text "Some text that will appear above the Fields" -Fields $MyFields
+Send-SlackNotification -Url "https://yourname.slack.com/path/to/hookintegrations" -Notification $notification
+
+----------------------------------------------------------------------
+In this example, $MyFields is defined as an Array. Inside that array are two separate hashtables with the two parameters that are required for a field. 
+Since the "short" boolean parameter has been speified these two fields will be displayed next to each other in Slack. 
+
+
 .LINK
 https://api.slack.com/docs/attachments
 
@@ -129,12 +167,12 @@ function New-SlackRichNotification
     (
         #<Attachment>
         [Parameter(Mandatory=$true,
-                   Position=0)]
+                    Position=0
+                    )]
         [String]
         $Fallback,
         
-        [Parameter(Mandatory=$false,
-                    Position=1)]
+        [Parameter(Mandatory=$false)]
         [ValidateSet("good",
                      "warning", 
                      "danger"
@@ -142,39 +180,31 @@ function New-SlackRichNotification
         [String]
         $Severity,
 
-        [Parameter(Mandatory=$false,
-                    ParameterSetName='Author Set'
-                    )]
+        [Parameter(Mandatory=$false)]
         [String]
         $AuthorName,
 
-        [Parameter(Mandatory=$false,
-                    ParameterSetName='Author Set'
-                    )]
+        [Parameter(Mandatory=$false)]
         [String]
         $AuthorLink,
 
-        [Parameter(Mandatory=$false,
-                    ParameterSetName='Author Set'
-                    )]
+        [Parameter(Mandatory=$false)]
         [String]
         $AuthorIcon,
 
-        [Parameter(Mandatory=$false, #this could be mandatory. This needs testing. 
-                   ParameterSetName='Title Set'
-                   )]
+        [Parameter(Mandatory=$false)] 
         [String]
         $Title,
 
-        [Parameter(Mandatory=$false,
-                   ParameterSetName='Title Set'
-                   )]
+        [Parameter(Mandatory=$false)]
         [String]
         $TitleLink,
         
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$false,
+                    Position=1
+                    )]
         [String]
-        $Text, #may be mandatory.
+        $Text,
 
         [Parameter(Mandatory=$false)]
         [String]
@@ -235,10 +265,3 @@ function New-SlackRichNotification
     {
     }
 }
-
-
-<#
-Change Notes:
-    - Removing positional paramater definition of optional parameters.
-
-#>


### PR DESCRIPTION
Hi @jgigler ,
I have made some fairly substantial changes to the New-SlackRichNotification function. 
The function now supports all of the API parameters for Attachments.  The only thing that can't be used as it is now is web colours in the Severity parameter.

I have tested all of the parameters together and they work.   
### Changes to New-SlackRichNotification:
- Changed the way fields are called in the command line. Now, to use a field, you have to put the field parameters into an array.  This allows the user to infinitely expand the fields which is in line with the way that the fields are used in the API.
- Added help for several new parameters and created an example of how to use fields.
- Made all parameters not mandatory except "Fallback" which is actually the only mandatory parameter in the API.
- "Fallback" and "Text" are now the only two positional parameters as those combined create the simplest form of message that this function can perform. Having more positional parameters would only serve to add ambiguity to any script where they are employed.
- Added the Pretext parameter as that one seems to have been missed.
- Added/Updated help for several parameters.
### Changes to Send-SlackNotification:
- Updated Help text for .DESCRIPTION .
