### PR TITLE
Fix for Issue #9 

### DIFF
--- a/Send-SlackMessage.ps1
+++ b/Send-SlackMessage.ps1
@@ -271,6 +271,7 @@ function New-SlackRichNotification
         $SlackNotification = @{
             username = $UserName
             icon_url = $IconUrl
+            channel = $Channel
             attachments = @(
                 @{                    
                     fallback = $Fallback


### PR DESCRIPTION
Though the Channel parameter was defined, it was not used anywhere in the code. Therefore if a user specified a channel to use, the message object was created without it and so the webhook would just use the default channel.  This has been fixed now. 
